### PR TITLE
Custom Dialog - Remove hidden class

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -23,13 +23,10 @@ Turbo.setConfirmMethod((message, element) => {
     dialog.querySelector('[data-confirm]').classList.add('hidden')
   }
 
-  dialog.classList.remove('hidden')
-
   dialog.showModal()
 
   return new Promise((resolve, reject) => {
     dialog.addEventListener("close", () => {
-      dialog.classList.add('hidden')
       resolve(dialog.returnValue === "confirm")
     }, { once: true })
   })

--- a/app/views/shared/_turbo_destroy_dialog.html.erb
+++ b/app/views/shared/_turbo_destroy_dialog.html.erb
@@ -1,4 +1,4 @@
-<dialog data-turbo-confirm-target="dialog" class="hidden">
+<dialog data-turbo-confirm-target="dialog">
   <div data-form="destroy" class="animated fadeIn fixed inset-0 overflow-y-auto flex items-center justify-center">
     <!-- Modal Inner Container -->
     <form method="dialog" class="max-h-screen w-full max-w-lg relative flex justify-center">


### PR DESCRIPTION
It turns out that the dialog is hidden by default unless the `open` attribute is present. You can remove the `hidden` class from the dialog HTML and associated JS logic.